### PR TITLE
Use license in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,12 +20,6 @@
     "type": "git",
     "url": "https://github.com/webpack/file-loader.git"
   },
-  "licenses": [
-    {
-      "type": "MIT",
-      "url": "http://www.opensource.org/licenses/mit-license.php"
-    }
-  ],
   "bugs": {
     "url": "https://github.com/webpack/file-loader/issues"
   },


### PR DESCRIPTION
Array deprecated in `npm@2.10.0`

https://github.com/npm/npm/blob/master/doc/files/package.json.md#license