### PR TITLE
Add "noEmit" option to don't copy files for server-side builds

### DIFF
--- a/index.js
+++ b/index.js
@@ -14,7 +14,9 @@ module.exports = function(content) {
 		content: content,
 		regExp: query.regExp
 	});
-	this.emitFile(url, content);
+	if (!query.noEmit) {
+		this.emitFile(url, content);
+	}
 	return "module.exports = __webpack_public_path__ + " + JSON.stringify(url);
 }
 module.exports.raw = true;


### PR DESCRIPTION
Related to #2. 
Not sure I understand problems with enhanced-require and __webpack_public_path__. 
For me everything works, the only problem is that for server-side build we don't actually need to emit files to output dir (which can actually differ from client's one), we only need a url for resource.
So just need ability to skip emitting, nothing more.