### PR TITLE
Remove unused dependency

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,7 +3,6 @@
 	Author Tobias Koppers @sokra
 */
 var loaderUtils = require("loader-utils");
-var path = require("path");
 
 module.exports = function(content) {
 	this.cacheable && this.cacheable();


### PR DESCRIPTION
Remove `var path = require("path");` because it's not used anywhere in the source.