### PR TITLE
Added a "publicPath" config option

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,12 +8,22 @@ module.exports = function(content) {
 	this.cacheable && this.cacheable();
 	if(!this.emitFile) throw new Error("emitFile is required from module system");
 	var query = loaderUtils.parseQuery(this.query);
+	var configKey = query.config || "fileLoader";
+	var config = this.options[configKey] || {};
 	var url = loaderUtils.interpolateName(this, query.name || "[hash].[ext]", {
 		context: query.context || this.options.context,
 		content: content,
 		regExp: query.regExp
 	});
+	var publicPath = config.publicPath;
+	if (publicPath) {
+		publicPath = (typeof publicPath === "function") ? publicPath(url) : publicPath + url;
+		publicPath = JSON.stringify(publicPath);
+	}
+	else {
+		publicPath = "__webpack_public_path__ + " + JSON.stringify(url);
+	}
 	this.emitFile(url, content);
-	return "module.exports = __webpack_public_path__ + " + JSON.stringify(url) + ";";
+	return "module.exports = " + publicPath + ";";
 }
 module.exports.raw = true;


### PR DESCRIPTION
For [domain sharding](http://abhishek-tiwari.com/post/CloudFront-design-patterns-and-best-practices) with hashed filenames, or splitting up build output assets by type or based on their source directories in a project, it's helpful to be able to differentiate the public path of the files emitted by the loader.

This PR is for a patch I've been using for a while now, and is a non-breaking change. I can also add tests for it if you like. It allows for a new query option, `path`, to be provided. `query.path` can be either a:

- String (e.g. `https://static.cdn.net/`)

  Since static assets are often served from a separate source than the application, this may be different from `options.output.publicPath`, and will be prepended to the output file path by the loader.

- Function, taking a single `path` argument, the file path from the loader, e.g.:

```javascript
function shard (path) {
    var hash = 0;
    var digit;
    for (var i = 0, length = path.length; i < length; i++) {
        hash = (((hash << 5) - hash) + path.charCodeAt(i)) & 0xFFFFFFFF;
    }
    digit = Math.abs(hash % 10);
    return 'https://static' + digit + '.cdn.net/' + path;
};
```

This allows assets to be sharded across domains based on a deterministic filename hash. Having deterministic output filenames is important for caching and linking of the assets (using React or another isomorphic rendering mechanism).