### PR TITLE
Added support for not emitting files for prerendering script.

### DIFF
--- a/locals.js
+++ b/locals.js
@@ -1,0 +1,17 @@
+/*
+	MIT License http://www.opensource.org/licenses/mit-license.php
+	Author Tobias Koppers @sokra
+*/
+var loaderUtils = require("loader-utils");
+
+module.exports = function(content) {
+	this.cacheable && this.cacheable();
+	var query = loaderUtils.parseQuery(this.query);
+	var url = loaderUtils.interpolateName(this, query.name || "[hash].[ext]", {
+		context: query.context || this.options.context,
+		content: content,
+		regExp: query.regExp
+	});
+	return "module.exports = __webpack_public_path__ + " + JSON.stringify(url) + ";";
+}
+module.exports.raw = true;

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "author": "Tobias Koppers @sokra",
   "description": "file loader module for webpack",
   "files": [
-    "index.js"
+    "index.js",
+    "locals.js"
   ],
   "dependencies": {
     "loader-utils": "~0.2.5"

--- a/test/locals.test.js
+++ b/test/locals.test.js
@@ -1,0 +1,24 @@
+var should = require("should");
+var fileLoaderLocals = require("../locals");
+
+function run(loader, content) {
+  var callCount = 0;
+  var context = {
+    resourcePath: "/this/is/dir/sub/file.txt",
+    query: "?name=[path][name].[ext]",
+    options: {
+      context: "/this/is/the/context"
+    },
+    emitFile: function() {
+      callCount += 1;
+    }
+  };
+  fileLoaderLocals.call(context, content);
+  return callCount;
+}
+
+describe("locals", function() {
+  it('should not emit a file', function () {
+    run(new Buffer("1234")).should.eql(0);
+  });
+});


### PR DESCRIPTION
The css-loader supports "css/locals". This will export the appropriate path, but will not emit any files. This file serves the same purpose. You can now use 'file/locals' to get a url reference, but without emitting a file. Files are typically emitted with a second webpack configuration that doesn't use "locals" anywhere.