### PR TITLE
Make emitting a file optional.

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,15 @@ var url = require("file!./file.png");
 By default the filename of the resulting file is the MD5 hash of the file's contents 
 with the original extension of the required resource.
 
+By default a file is emitted, however this can be disabled if required (e.g. for server
+side packages).
+
+``` javascript
+var url = require("file?emitFile=false!./file.png");
+// => returns the public url but does NOT emit a file
+// => returns i. e. "/public-path/0dcbbaa701328a3c262cfd45869e351f.png"
+```
+
 ## Filename templates
 
 You can configure a custom filename template for your file using the query

--- a/index.js
+++ b/index.js
@@ -13,7 +13,10 @@ module.exports = function(content) {
 		content: content,
 		regExp: query.regExp
 	});
-	this.emitFile(url, content);
+
+	if (query.emitFile === undefined || query.emitFile) {
+		this.emitFile(url, content);
+	}
 	return "module.exports = __webpack_public_path__ + " + JSON.stringify(url) + ";";
 }
 module.exports.raw = true;

--- a/test/optional-file-emission.test.js
+++ b/test/optional-file-emission.test.js
@@ -1,0 +1,29 @@
+var should = require("should");
+var fileLoader = require("../");
+
+function run(resourcePath, query, content) {
+	content = content || new Buffer("1234");
+	var result = false;
+	var context = {
+		resourcePath: resourcePath,
+		query: "?" + query,
+		options: {
+			context: "/this/is/the/context"
+		},
+		emitFile: function(url, content2) {
+			result = true;
+		}
+	};
+	fileLoader.call(context, content);
+	return result;
+}
+
+describe("optional-emission", function() {
+	it("should emit a file by default", function() {
+		run("whatever.txt", "").should.be.true;
+	});
+
+	it("should not emit a file if disabled", function() {
+		run("whatever.txt", "emitFile=false").should.be.false;
+	});
+});


### PR DESCRIPTION
When building server side packages there may be no need to emit a file;
this makes file emission optional, while keeping the default behaviour
as is.

Resolves #59 