### PR TITLE
chore(readme): Update to webpack standard format

### DIFF
--- a/.github/assets/file_loader_icon.svg
+++ b/.github/assets/file_loader_icon.svg
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="200px" height="200px" viewBox="0 0 200 200" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    <!-- Generator: Sketch 41.2 (35397) - http://www.bohemiancoding.com/sketch -->
+    <title>file_loader_icon</title>
+    <desc>Created with Sketch.</desc>
+    <defs>
+        <circle id="path-1" cx="64" cy="64" r="64"></circle>
+        <path d="M46,0 L4,0 C1.791,0 0,1.791 0,4 L0,76 C0,78.209 1.791,80 4,80 L60,80 C62.209,80 64,78.209 64,76 L64,18 L46,0 Z" id="path-3"></path>
+    </defs>
+    <g id="Page-1" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
+        <g id="file_loader_icon">
+            <circle id="Oval" fill="#EAEFF0" cx="64" cy="64" r="64"></circle>
+            <g id="Background">
+                <mask id="mask-2" fill="white">
+                    <use xlink:href="#path-1"></use>
+                </mask>
+                <g id="SVGID_9_"></g>
+                <polygon id="Shape" fill="#D4D7DE" opacity="0.55" mask="url(#mask-2)" points="33.096 102.746 58.351 128 128 128 128 73.888 96 42"></polygon>
+            </g>
+            <path d="M78,24 L36,24 C33.791,24 32,25.791 32,28 L32,100 C32,102.209 33.791,104 36,104 L92,104 C94.209,104 96,102.209 96,100 L96,42 L78,24 Z" id="Shape" fill="#2195CD"></path>
+            <g id="Icon" transform="translate(32.000000, 24.000000)">
+                <mask id="mask-4" fill="white">
+                    <use xlink:href="#path-3"></use>
+                </mask>
+                <use id="layer1" fill="#4D9BD8" xlink:href="#path-3"></use>
+                <rect id="bottom" fill="#1C78C0" mask="url(#mask-4)" x="0" y="48" width="64" height="36"></rect>
+                <path d="M52,18 L64,18 L46,0 L46,12 C46,15.314 48.686,18 52,18 Z" id="fold" fill="#8ED6FB" mask="url(#mask-4)"></path>
+            </g>
+            <g id="text" transform="translate(42.000000, 74.000000)" font-size="20" font-family="Roboto-Regular, Roboto" fill="#FFFFFF" font-weight="normal">
+                <text id="file://">
+                    <tspan x="0" y="21">file://</tspan>
+                </text>
+            </g>
+        </g>
+    </g>
+</svg>

--- a/README.md
+++ b/README.md
@@ -1,17 +1,36 @@
-# file loader for webpack
+[![npm][npm]][npm-url]
+[![node][node]][node-url]
+[![deps][deps]][deps-url]
+[![tests][tests]][tests-url]
+[![coverage][cover]][cover-url]
+[![chat][chat]][chat-url]
 
-## Usage
+<div align="center">
+  <img width="200" height="200"
+    src="https://cdn.rawgit.com/webpack/file-loader/tree/master/.github/assets/file_loader_icon.svg">
+  <a href="https://github.com/webpack/webpack">
+    <img width="200" height="200"
+      src="https://webpack.js.org/assets/icon-square-big.svg">
+  </a>
+  <h1>File Loader</h1>
+</div>
 
-[Documentation: Using loaders](http://webpack.github.io/docs/using-loaders.html)
+<h2 align="center">Install</h2>
+
+```bash
+npm install --save-dev file-loader
+```
+
+<h2 align="center">Usage</h2>
+
+By default the filename of the resulting file is the MD5 hash of the file's contents
+with the original extension of the required resource.
 
 ``` javascript
 var url = require("file-loader!./file.png");
 // => emits file.png as file in the output directory and returns the public url
 // => returns i. e. "/public-path/0dcbbaa701328a3c262cfd45869e351f.png"
 ```
-
-By default the filename of the resulting file is the MD5 hash of the file's contents
-with the original extension of the required resource.
 
 By default a file is emitted, however this can be disabled if required (e.g. for server
 side packages).
@@ -22,7 +41,7 @@ var url = require("file-loader?emitFile=false!./file.png");
 // => returns i. e. "/public-path/0dcbbaa701328a3c262cfd45869e351f.png"
 ```
 
-## Filename templates
+#### Filename templates
 
 You can configure a custom filename template for your file using the query parameter `name`. For instance, to copy a file from your `context` directory into the output directory retaining the full directory structure, you might use `?name=[path][name].[ext]`.
 
@@ -31,10 +50,10 @@ By default, the path and name you specify will output the file in that same dire
 You can specify custom output and public paths by using the `outputPath` and `publicPath` query name parameters:
 
 ```
-loader: "file-loader?name=[name].[ext]&publicPath=assets/foo/&outputPath=app/images/"
+use: "file-loader?name=[name].[ext]&publicPath=assets/foo/&outputPath=app/images/"
 ```
 
-### Filename template placeholders
+#### Filename template placeholders
 
 * `[ext]` the extension of the resource
 * `[name]` the basename of the resource
@@ -46,7 +65,7 @@ loader: "file-loader?name=[name].[ext]&publicPath=assets/foo/&outputPath=app/ima
   * and `length` the length in chars
 * `[N]` the N-th match obtained from matching the current file name against the query param `regExp`
 
-## Examples
+#### Examples
 
 ``` javascript
 require("file-loader?name=js/[hash].script.[ext]!./javascript.js");
@@ -73,10 +92,56 @@ require("file-loader?name=[path][name].[ext]?[hash]!./dir/file.png")
 // => dir/file.png?e43b20c069c4a01867c31e98cbce33c9
 ```
 
-## Installation
+<h2 align="center">Contributing</h2>
 
-```npm install file-loader --save-dev```
+Don't hesitate to create a pull request. Every contribution is appreciated. In development you can start the tests by calling `npm test`.
 
-## License
+<h2 align="center">Maintainers</h2>
 
-MIT (http://www.opensource.org/licenses/mit-license.php)
+<table>
+  <tbody>
+    <tr>
+      <td align="center">
+        <img width="150 height="150"
+        src="https://avatars.githubusercontent.com/sokra?v=3">
+        <br />
+        <a href="https://github.com/">Tobias Koppers</a>
+      </td>
+      <td align="center">
+        <img width="150 height="150"
+        src="https://avatars.githubusercontent.com/SpaceK33z?v=3">
+        <br />
+        <a href="https://github.com/">Kees Kluskens</a>
+      </td>
+      <td align="center">
+        <img width="150 height="150"
+        src="https://avatars.githubusercontent.com/mobitar?v=3">
+        <br />
+        <a href="https://github.com/">Mo Bitar</a>
+      </td>
+    <tr>
+  <tbody>
+</table>
+
+
+<h2 align="center">LICENSE</h2>
+
+#### [MIT](./LICENSE)
+
+[npm]: https://img.shields.io/npm/v/file-loader.svg
+[npm-url]: https://npmjs.com/package/file-loader
+
+[node]: https://img.shields.io/node/v/file-loader.svg
+[node-url]: https://nodejs.org
+
+[deps]: https://david-dm.org/webpack/file-loader.svg
+[deps-url]: https://david-dm.org/webpack/file-loader
+
+[tests]: http://img.shields.io/travis/webpack/file-loader.svg
+[tests-url]: https://travis-ci.org/webpack/file-loader
+
+[cover]: https://coveralls.io/repos/github/webpack/file-loader/badge.svg
+[cover-url]: https://coveralls.io/github/webpack/file-loader
+
+[chat]: https://badges.gitter.im/webpack/webpack.svg
+[chat-url]: https://gitter.im/webpack/webpack


### PR DESCRIPTION
Updates Readme to the Webpack standard format per @TheLarkInn in webpack/webpack#3195

> header image is a rawgit url that will resolve when the attached image lands in master.