### PR TITLE
Fix Maintainers section look

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,25 +102,25 @@ Don't hesitate to create a pull request. Every contribution is appreciated. In d
   <tbody>
     <tr>
       <td align="center">
-        <img width="150 height="150"
+        <img width="150" height="150"
         src="https://avatars.githubusercontent.com/sokra?v=3">
         <br />
         <a href="https://github.com/">Tobias Koppers</a>
       </td>
       <td align="center">
-        <img width="150 height="150"
+        <img width="150" height="150"
         src="https://avatars.githubusercontent.com/SpaceK33z?v=3">
         <br />
         <a href="https://github.com/">Kees Kluskens</a>
       </td>
       <td align="center">
-        <img width="150 height="150"
+        <img width="150" height="150"
         src="https://avatars.githubusercontent.com/mobitar?v=3">
         <br />
         <a href="https://github.com/">Mo Bitar</a>
       </td>
-    <tr>
-  <tbody>
+    </tr>
+  </tbody>
 </table>
 
 


### PR DESCRIPTION
**What kind of change does this PR introduce?**
Fix Maintainer section HTML

**Did you add tests for your changes?**
No

**If relevant, did you update the README?**
Yes

**Summary**

Maintainers section HTML was incorrect, making the website look like this:
![image](https://cloud.githubusercontent.com/assets/1002461/22202500/6a1a167e-e136-11e6-942e-faa7832337c9.png)

After the change it looks like this:
![image](https://cloud.githubusercontent.com/assets/1002461/22202503/6d629036-e136-11e6-97f0-c243e634ff86.png)


